### PR TITLE
switch to using sdca r package

### DIFF
--- a/api/test.R
+++ b/api/test.R
@@ -1,11 +1,8 @@
 #!/usr/bin/env Rscript
 
 
-# Algorithm function
-process_results = function(args) {
-	values = unlist(strsplit(args, ','))
-	result = length(values)
-}
+# Load Package
+library(sdca)
 
 # Get data values from STDIN
 # See: https://datafireball.com/2013/10/10/putting-your-r-code-into-pipeline/comment-page-1/
@@ -13,7 +10,13 @@ input = file('stdin', 'r');
 args = readLines(input, n=1, warn=FALSE)
 
 # Process the data
-result = process_results(args)
+result = try(process_results(args), silent = TRUE)
+
+# Check if the function worked
+if("try-error" %in% class(result)){
+  result = list(error = gsub("[\r\n]", "", result[1]))
+  result = jsonlite::toJSON(result)
+}
 
 # Print the result, without newlines or a count
 cat(result)


### PR DESCRIPTION
Hi @mvl22 

I'm changing the test.R script to use the sdca R package. Currently, the process_results function always returns the same results regardless of input but it should give a rough idea of the structure of the data we are expecting to return.

I've also added some crude error handling, so that if my code fails an error message can be returned.

We will need to agree on what input data the API will provide to R at the meeting.

Malcolm
